### PR TITLE
bug: Fix Compile API header prefix.

### DIFF
--- a/src/OpenPolicyAgent.Opa/Filters/TargetDialect.cs
+++ b/src/OpenPolicyAgent.Opa/Filters/TargetDialect.cs
@@ -64,20 +64,20 @@ public static class TargetDialectsExtension
     /// Generates an HTTP <c>Accept</c> header string for use with EOPA's Compile API.
     /// </summary>
     /// <param name="value">The TargetDialects value to use.</param>
-    /// <returns>An <c>Accept</c> header string of the format <c>application/vnd.open-policy-agent.${data_filter_type}+json</c>.</returns>
+    /// <returns>An <c>Accept</c> header string of the format <c>application/vnd.opa.${data_filter_type}+json</c>.</returns>
     /// <remarks>See: <see href="https://github.com/open-policy-agent/eopa/blob/main/docs/eopa/reference/api-reference/partial-evaluation-api.md#accept-header--controlling-the-target-response-format"/></remarks>
     public static string ToAcceptHeader(this TargetDialects value)
     {
         return value switch
         {
-            TargetDialects.UcastAll => "application/vnd.open-policy-agent.ucast.all+json",
-            TargetDialects.UcastMinimal => "application/vnd.open-policy-agent.ucast.minimal+json",
-            TargetDialects.UcastPrisma => "application/vnd.open-policy-agent.ucast.prisma+json",
-            TargetDialects.UcastLinq => "application/vnd.open-policy-agent.ucast.linq+json",
-            TargetDialects.SqlSqlserver => "application/vnd.open-policy-agent.sql.sqlserver+json",
-            TargetDialects.SqlMysql => "application/vnd.open-policy-agent.sql.mysql+json",
-            TargetDialects.SqlPostgresql => "application/vnd.open-policy-agent.sql.postgresql+json",
-            TargetDialects.SqlSqlite => "application/vnd.open-policy-agent.sql.sqlite+json",
+            TargetDialects.UcastAll => "application/vnd.opa.ucast.all+json",
+            TargetDialects.UcastMinimal => "application/vnd.opa.ucast.minimal+json",
+            TargetDialects.UcastPrisma => "application/vnd.opa.ucast.prisma+json",
+            TargetDialects.UcastLinq => "application/vnd.opa.ucast.linq+json",
+            TargetDialects.SqlSqlserver => "application/vnd.opa.sql.sqlserver+json",
+            TargetDialects.SqlMysql => "application/vnd.opa.sql.mysql+json",
+            TargetDialects.SqlPostgresql => "application/vnd.opa.sql.postgresql+json",
+            TargetDialects.SqlSqlite => "application/vnd.opa.sql.sqlite+json",
             _ => "application/json",
         };
     }

--- a/src/OpenPolicyAgent.Opa/OpaClient.cs
+++ b/src/OpenPolicyAgent.Opa/OpaClient.cs
@@ -728,7 +728,7 @@ public class OpaClient
         string acceptHeader = targetDialects.Count switch
         {
             1 => targetDialects[0].ToAcceptHeader(),
-            _ => "application/vnd.open-policy-agent.multitarget+json",
+            _ => "application/vnd.opa.multitarget+json",
         };
 
         // Serialize request object to JSON

--- a/src/OpenPolicyAgent.Opa/OpenApi/OpaApiClient.cs
+++ b/src/OpenPolicyAgent.Opa/OpenApi/OpaApiClient.cs
@@ -665,7 +665,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultJSON = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.multitarget+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.multitarget+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultMultitarget>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -677,7 +677,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultMultitarget = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.ucast.all+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.ucast.all+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultUCAST>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -689,7 +689,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultUCAST = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.ucast.linq+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.ucast.linq+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultUCAST>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -701,7 +701,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultUCAST = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.ucast.minimal+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.ucast.minimal+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultUCAST>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -713,7 +713,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultUCAST = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.ucast.prisma+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.ucast.prisma+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultUCAST>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -725,7 +725,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultUCAST = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.sql.mysql+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.sql.mysql+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultSQL>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -737,7 +737,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultSQL = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.sql.postgresql+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.sql.postgresql+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultSQL>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -749,7 +749,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultSQL = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.sql.sqlite+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.sql.sqlite+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultSQL>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()
@@ -761,7 +761,7 @@ namespace OpenPolicyAgent.Opa.OpenApi
                     response.CompileResultSQL = obj;
                     return response;
                 }
-                else if (Utilities.IsContentTypeMatch("application/vnd.open-policy-agent.sql.sqlserver+json", contentType))
+                else if (Utilities.IsContentTypeMatch("application/vnd.opa.sql.sqlserver+json", contentType))
                 {
                     var obj = ResponseBodyDeserializer.Deserialize<CompileResultSQL>(await httpResponse.Content.ReadAsStringAsync(), NullValueHandling.Ignore);
                     var response = new CompileQueryWithPartialEvaluationResponse()

--- a/test/SmokeTest.Tests/EOPAContainerFixture.cs
+++ b/test/SmokeTest.Tests/EOPAContainerFixture.cs
@@ -19,14 +19,12 @@ public class EOPAContainerFixture : IAsyncLifetime
             "testdata/filters/filters.rego",
             "testdata/filters/roles.json"
         };
-        string[] opaCmd = ["run", "--server", "--addr=0.0.0.0:8181", "--disable-telemetry"];
+        string[] opaCmd = ["run", "--server", "--addr=0.0.0.0:8181"];
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.
         var container = new ContainerBuilder()
           .WithImage("ghcr.io/open-policy-agent/eopa:latest")
-          .WithEnvironment("EOPA_LICENSE_TOKEN", Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN"))
-          .WithEnvironment("EOPA_LICENSE_KEY", Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY"))
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)

--- a/test/SmokeTest.Tests/HighLevelTest.cs
+++ b/test/SmokeTest.Tests/HighLevelTest.cs
@@ -866,7 +866,6 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   [Fact]
   public async Task GetFiltersTest()
   {
-    Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
     var client = GetEOpaClient();
 
     var (filters, masks) = await client.GetFilters("filters/include", new Dictionary<string, object>
@@ -918,7 +917,6 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   [Fact]
   public async Task GetFiltersWithMasksTest()
   {
-    Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
     var client = GetEOpaClient();
 
     // Result here should be identical to the filters-oriented test, but our
@@ -946,7 +944,6 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   [Fact]
   public async Task GetFiltersMultiTargetTest()
   {
-    Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
     var client = GetEOpaClient();
 
     var (filters, masks) = await client.GetMultipleFilters("filters/include", new Dictionary<string, object>()
@@ -1012,7 +1009,6 @@ public class HighLevelTest : IClassFixture<OPAContainerFixture>, IClassFixture<E
   [Fact]
   public async Task GetFiltersMultiTargetWithMasksTest()
   {
-    Assert.SkipWhen(NoEOPALicenseEnvVarsFound(), "No EOPA license variables provided at test launch time.");
     var client = GetEOpaClient();
 
     // Result here should be identical to the filters-oriented test, but our

--- a/test/SmokeTest.Tests/testdata/filters/filters.rego
+++ b/test/SmokeTest.Tests/testdata/filters/filters.rego
@@ -1,6 +1,6 @@
 # METADATA
 # scope: package
-# custom:
+# compile:
 #   unknowns:
 #     - input.tickets
 #     - input.users


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This commit refactors our Compile API application headers to use `vnd.opa.<target>` format.

Currently, only EOPA's Compile API endpoints are tested for data filters.

### :+1: Definition of done

 - Tests run successfully. (Should happen on the next EOPA release.)

### :athletic_shoe: How to test

 - Github Actions CI
 - Locally: `dotnet test`

### :chains: Related Resources

