### PR TITLE
deps: Adjust NuGet search paths.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: nuget
-    directory: /
+    directory:
+      - "/"
+      - "/src"
+      - "/test"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Dependabot doesn't seem to be updating both the `src/...` and `test/...` `.csproj` files. (See #155 for an example of where it updates one file, but not the other.)

According to some Github issues dug up by search, it looks like we *might* get better results if we attempt to be more explicit with Dependabot, and don't rely on it transitively picking up dependencies just from the top-level `.sln` file. (Even though that's supposed to "just work". :shrug:)

### :athletic_shoe: How to test

 - Merge PR.
 - Have Dependabot recreate PRs.
 - See if the change causes the `test/...` `.csproj` file to be picked up?

### :chains: Related Resources

 - https://github.com/dependabot/dependabot-core/issues/10145
 - (Similar modality, slightly different issue): https://github.com/dependabot/dependabot-core/issues/9444
